### PR TITLE
Add check for null tool set.

### DIFF
--- a/src/jit-diff/jit-diff.cs
+++ b/src/jit-diff/jit-diff.cs
@@ -1297,7 +1297,14 @@ namespace ManagedCodeGen
                 if (Path.GetFileName(dir).ToUpper().Contains(config.Moniker.ToUpper()))
                 {
                     newTool.Add("path", Path.GetFullPath(dir));
-                    tools.Last.AddAfterSelf(newTool);
+                    if (tools.HasValues)
+                    {
+                        tools.Last.AddAfterSelf(newTool);
+                    }
+                    else
+                    {
+                        tools.Add(newTool);
+                    }
                     break;
                 }
             }


### PR DESCRIPTION
If there were no prior installed tools we would run into a
null exception.  Add code for the case where the install is the
first one.